### PR TITLE
Support multiple inputs in a single validator-wrapper

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
     {
       files: [
         '.eslintrc.js',
+        'prettier.config.js',
         '.prettierrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',

--- a/addon/components/validator-wrapper.hbs
+++ b/addon/components/validator-wrapper.hbs
@@ -1,6 +1,6 @@
 <div
-  {{did-update this.onReceiveProperties value=@value}}
-  {{did-insert this.onReceiveProperties value=@value}}
+  {{did-update this.onReceiveProperties @model}}
+  {{did-insert this.onReceiveProperties @model}}
   >
   {{yield (hash errorMessage=this.errorMessage)}}
 </div>

--- a/addon/components/validator-wrapper.hbs
+++ b/addon/components/validator-wrapper.hbs
@@ -1,6 +1,6 @@
 <div
-  {{did-update this.onUpdate value=@value}}
-  {{did-insert this.onUpdate value=@value}}
+  {{did-update this.onReceiveProperties value=@value}}
+  {{did-insert this.onReceiveProperties value=@value}}
   >
   {{yield (hash errorMessage=this.errorMessage)}}
 </div>

--- a/addon/components/validator-wrapper.hbs
+++ b/addon/components/validator-wrapper.hbs
@@ -1,6 +1,6 @@
 <div
   {{did-update this.onReceiveProperties @model}}
-  {{did-insert this.onReceiveProperties @model}}
+  {{did-insert this.onInsert @model}}
   >
   {{yield (hash errorMessage=this.errorMessage)}}
 </div>

--- a/addon/components/validator-wrapper.js
+++ b/addon/components/validator-wrapper.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { action, set } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
+import { isEmpty } from '@ember/utils';
 
 /**
  * The error type will be returned when validate against a component with multiple input fields
@@ -49,13 +50,13 @@ export default class ValidatorWrapper extends Component {
    * The error message will be used to print the error message
    * @type {string}
    */
-  @tracked error = '';
+  @tracked error = {};
 
   /**
    * A reference point to the last invalid input field, will be used to reset before a new round of validation
    * @type {DOMNode}
    */
-  lastElementWithCustomError = null;
+  hadCustomError = false;
 
   /**
    * proxied error message based on the `validating` flag
@@ -72,10 +73,10 @@ export default class ValidatorWrapper extends Component {
    *   the input component and the custom validator functions
    * @returns {ErrorObject}
    */
-  customValidate(...args) {
+  _customValidate() {
     if (Array.isArray(this.args.validators)) {
       for (const validator of this.args.validators) {
-        const result = validator(...args);
+        const result = validator(this.args.model);
 
         if (result) return result;
       }
@@ -94,38 +95,41 @@ export default class ValidatorWrapper extends Component {
    *   the input component and the custom validator functions
    * @returns {string}
    */
-  _getCustomError(element, ...args) {
+  _getCustomError(element) {
     if (!this.args.validators) return '';
 
-    const error = this.customValidate(...args);
+    const error = this._customValidate(element);
 
     if (!error) {
-      this.lastElementWithCustomError = null;
-
-      return '';
-    } else if (typeof error === 'string') {
+      this.hadCustomError = false;
+      return undefined;
+    } else if (typeof error === 'object') {
       this._setCustomValidity(element, error, /** isAriaInvalid*/ true);
-      this.lastElementWithCustomError = element;
+      this.hadCustomError = true;
 
       return error;
     }
 
-    return '';
+    return undefined;
   }
 
   /**
    * Helper function to set or clear the error attributes on the element. It handles the error differently
    * based on whether or not `setCustomValidity` is available function on this element.
    * @param {Element} invalidElement
-   * @param {String} errorMessage
+   * @param {object} error
    * @param {Boolean} isAriaInvalid
    */
-  _setCustomValidity(invalidElement, errorMessage, isAriaInvalid) {
-    if (!invalidElement.setCustomValidity) {
-      invalidElement.dataset.errorMessage = errorMessage;
-      invalidElement.setAttribute('aria-invalid', isAriaInvalid);
-    } else {
-      invalidElement.setCustomValidity(errorMessage);
+  _setCustomValidity(rootElement, error, isAriaInvalid) {
+    for (const inputName in this.args.model) {
+      const invalidElement = rootElement.querySelector(`[name=${inputName}]`);
+      if (!invalidElement.setCustomValidity) {
+        // TODO bear - work on artificial validation later
+        // invalidElement.dataset.errorMessage = errorMessage;
+        // invalidElement.setAttribute('aria-invalid', isAriaInvalid);
+      } else {
+        invalidElement.setCustomValidity(error[inputName] ?? '');
+      }
     }
   }
 
@@ -136,34 +140,36 @@ export default class ValidatorWrapper extends Component {
    * @returns {String} error string, empty string (`''`) if no error
    */
   _collectConstraintViolation(rootElement) {
-    const element = rootElement.querySelector('input,select') ?? rootElement;
-    if (
-      element.validity &&
-      !element.validity.customError &&
-      !element.validity.valid
-    ) {
-      // TODO @bear
-      // if (element.validity.valueMissing) {
-      // } else if (element.validity.typeMismatch) {
-      // } else if (element.validity.patternMismatch) {
-      // }
-      // TODO bhsiung - support min (rangeUnderflow) & max (rangeOverflow) for type=number
-      // TODO bhsiung - support minlength (tooShort) & maxlength (tooLong)
-      return element.validationMessage;
+    let elements = rootElement.querySelectorAll('input,select') ?? [
+      rootElement,
+    ];
+    const error = {};
+    let hasError = false;
+    for (const element of elements) {
+      if (
+        element.validity &&
+        !element.validity.customError &&
+        !element.validity.valid
+      ) {
+        // TODO @bear
+        // if (element.validity.valueMissing) {
+        // } else if (element.validity.typeMismatch) {
+        // } else if (element.validity.patternMismatch) {
+        // }
+        // TODO bhsiung - support min (rangeUnderflow) & max (rangeOverflow) for type=number
+        // TODO bhsiung - support minlength (tooShort) & maxlength (tooLong)
+        error[element.name] = element.validationMessage;
+        hasError = true;
+      }
     }
 
-    return undefined;
+    return hasError ? error : undefined;
   }
 
   @action
   onReceiveProperties(element) {
-    this.inputElement = element.querySelector('input,select');
-    assert(
-      'more than 2 input elements detected within the component, only the first one will be used for validation',
-      element.querySelectorAll('input,select').length === 1
-    );
-
-    this.contextualValidator(this.inputElement, this.args.value);
+    console.log(1233);
+    this.contextualValidator(element);
   }
 
   /**
@@ -174,28 +180,25 @@ export default class ValidatorWrapper extends Component {
    *   the input component and the custom validator functions
    * @return {string}
    */
-  @action contextualValidator(rootElement, ...args) {
-    if (this.lastElementWithCustomError) {
+  @action contextualValidator(rootElement) {
+    if (this.hadCustomError) {
       // this is needed for a corner case. assume both constraint and custom validator exists, a
       // node failed on custom validation from the last execution, user fixed it but violate the
       // constraint validation immediately. There is no easy way to tell if there is constraint
       // validation without rest the custom error first
       this._setCustomValidity(
-        this.lastElementWithCustomError,
-        /** errorMessage */ '',
+        rootElement,
+        /** errorMessage */ {},
         /** isAriaInvalid*/ false
       );
     }
 
-    console.log(
-      this._collectConstraintViolation(rootElement) ??
-        this._getCustomError(rootElement, ...args)
-    );
     return set(
       this,
       'error',
       this._collectConstraintViolation(rootElement) ??
-        this._getCustomError(rootElement, ...args)
+        this._getCustomError(rootElement) ??
+        {}
     );
   }
 }

--- a/addon/components/validator-wrapper.js
+++ b/addon/components/validator-wrapper.js
@@ -182,7 +182,7 @@ export default class ValidatorWrapper extends Component {
     this.targetInputNames = intersection(modelKeys, inputNames);
     warn(
       'Discovered some inputs does not have a `name` attribute, they will be ignored while validating',
-      element.querySelectorAll('input:not([name]),select:not([name])').length,
+      !element.querySelectorAll('input:not([name]),select:not([name])').length,
       { id: 'ember-form-validation.input-without-name-attr' }
     );
   }

--- a/addon/components/validator-wrapper.js
+++ b/addon/components/validator-wrapper.js
@@ -73,7 +73,7 @@ export default class ValidatorWrapper extends Component {
    * @returns {ErrorObject}
    */
   _customValidate() {
-    const validators = this._getValidators();
+    const validators = this.validators;
     for (const validator of validators) {
       const result = validator(this.args.model);
 
@@ -83,28 +83,22 @@ export default class ValidatorWrapper extends Component {
     return null;
   }
 
-  _getValidators() {
+  get validators() {
     return this.args.validators ?? [this.args.validator];
   }
 
   /**
-   * 1. perform validation
-   * 2. associate error message to input element
-   * 3. cache invalid element
-   *
    * @param {DOMNode} rootElement - the root element of the input field
-   * @param {array} ...args - the information needed for validation. this part requires a co-op between
-   *   the input component and the custom validator functions
-   * @returns {string}
+   * @returns {object}
    */
   _getCustomError(element) {
-    if (!this._getValidators()) return undefined;
+    if (this.validators.length === 0) return {};
 
     const error = this._customValidate(element);
 
     if (!error) {
       this.hadCustomError = false;
-      return undefined;
+      return {};
     } else if (typeof error === 'object') {
       this._setCustomValidity(element, error, /** isAriaInvalid*/ true);
       this.hadCustomError = true;
@@ -112,7 +106,7 @@ export default class ValidatorWrapper extends Component {
       return error;
     }
 
-    return undefined;
+    return {};
   }
 
   /**

--- a/addon/components/validator-wrapper.js
+++ b/addon/components/validator-wrapper.js
@@ -156,8 +156,7 @@ export default class ValidatorWrapper extends Component {
   }
 
   @action
-  onUpdate(element) {
-    console.log('update');
+  onReceiveProperties(element) {
     this.inputElement = element.querySelector('input,select');
     assert(
       'more than 2 input elements detected within the component, only the first one will be used for validation',
@@ -167,9 +166,6 @@ export default class ValidatorWrapper extends Component {
     this.contextualValidator(this.inputElement, this.args.value);
   }
 
-  onInsert() {
-    console.log('insert');
-  }
   /**
    * Perform a series of form validation, will be invoked by form input field (oninput)
    *

--- a/addon/components/validator-wrapper.js
+++ b/addon/components/validator-wrapper.js
@@ -63,7 +63,7 @@ export default class ValidatorWrapper extends Component {
    * @type {string}
    */
   get errorMessage() {
-    return this.args.validating ? this.error : '';
+    return this.args.validating ? this.error : {};
   }
 
   /**
@@ -74,8 +74,8 @@ export default class ValidatorWrapper extends Component {
    * @returns {ErrorObject}
    */
   _customValidate() {
-    if (Array.isArray(this.args.validators)) {
-      for (const validator of this.args.validators) {
+    if (Array.isArray(this._getValidators())) {
+      for (const validator of this._getValidators()) {
         const result = validator(this.args.model);
 
         if (result) return result;
@@ -83,6 +83,10 @@ export default class ValidatorWrapper extends Component {
     }
 
     return null;
+  }
+
+  _getValidators() {
+    return this.args.validators ?? [this.args.validator];
   }
 
   /**
@@ -96,7 +100,7 @@ export default class ValidatorWrapper extends Component {
    * @returns {string}
    */
   _getCustomError(element) {
-    if (!this.args.validators) return '';
+    if (!this._getValidators()) return undefined;
 
     const error = this._customValidate(element);
 

--- a/addon/components/validator-wrapper.js
+++ b/addon/components/validator-wrapper.js
@@ -1,10 +1,8 @@
 import Component from '@glimmer/component';
 import { action, setProperties } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { intersection } from 'ember-form-validation/utils/array-helpers';
 
-function intersection(arr1, arr2) {
-  return arr1.filter((key) => arr2.includes(key));
-}
 /**
  * The error type will be returned when validate against a component with multiple input fields
  * The structure allow identifying the error message to a specific element based on the `name`

--- a/addon/utils/array-helpers.js
+++ b/addon/utils/array-helpers.js
@@ -1,0 +1,3 @@
+export function intersection(arr1, arr2) {
+  return arr1.filter((key) => arr2.includes(key));
+}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "ember-source": "~3.27.2",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^3.4.2",
+    "ember-truth-helpers": "^3.0.0",
     "ember-try": "^1.4.0",
     "eslint": "^7.27.0",
     "eslint-config-prettier": "^8.3.0",

--- a/tests/integration/components/validator-wrapper-test.js
+++ b/tests/integration/components/validator-wrapper-test.js
@@ -4,7 +4,6 @@ import { click, fillIn, find, render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 const LINKEDIN_EMAIL_ERROR = 'LINKEDIN_EMAIL_ERROR';
-const LINKEDIN_URL_ERROR = 'LINKEDIN_URL_ERROR';
 const MS_EMAIL_ERROR = 'MS_EMAIL_ERROR';
 const NOT_EMPTY_ERROR = 'NOT_EMPTY_ERROR';
 

--- a/tests/integration/components/validator-wrapper-test.js
+++ b/tests/integration/components/validator-wrapper-test.js
@@ -52,6 +52,10 @@ module('Integration | Component | validator-wrapper', (hooks) => {
       const element = e.target;
       that.set('value', element.value);
     };
+    this.onInput2 = function (e) {
+      const element = e.target;
+      that.set('value2', element.value);
+    };
   });
   skip('it validates contenteditable field', async function (assert) {
     this.validateNotEmpty = validateNotEmpty;
@@ -79,8 +83,8 @@ module('Integration | Component | validator-wrapper', (hooks) => {
           name="rich-text-editor"
           required=true
         }}
-        {{#if validity.errorMessage}}
-          <p data-test-error>{{validity.errorMessage}}</p>
+        {{#if (get v.errorMessage "rich-text-editor")}}
+          <p data-test-error>{{(get v.errorMessage "simple-email")}}</p>
         {{/if}}
       {{/validator-wrapper}}
     `);
@@ -140,8 +144,8 @@ module('Integration | Component | validator-wrapper', (hooks) => {
           onInput={{fn this.onInput}}
           pattern=".+\.com"
         />
-        {{#if v.errorMessage}}
-          <p data-test-error>{{v.errorMessage}}</p>
+        {{#if (get v.errorMessage "simple-email")}}
+          <p data-test-error>{{(get v.errorMessage "simple-email")}}</p>
         {{/if}}
       {{/validator-wrapper}}
     `);
@@ -237,6 +241,45 @@ module('Integration | Component | validator-wrapper', (hooks) => {
   });
 
   test('can handle multiple input', async function (assert) {
+    this.value = '';
+    this.value2 = '';
+
+    await render(hbs`
+      {{#validator-wrapper
+        validators=(array this.notLinkedinEmail this.notMsEmail)
+        validating=true
+        value=this.value
+        as |v|
+      }}
+        <input
+          type="email"
+          required
+          name="simple-email"
+          data-test-input
+          value={{this.value}}
+          onInput={{fn this.onInput}}
+          pattern=".+\.com"
+        />
+        {{#if (get v.errorMessage "simple-email")}}
+          <p data-test-error>{{(get v.errorMessage "simple-email")}}</p>
+        {{/if}}
+        <fieldset name="gender-set" {{on "input" this.onInput2}}>
+          <input id="field2-bar" type="radio" name="field2" value="bar" checked={{eq value2 "bar"}} required />
+          <label for="field2-bar">bar</label>
+          <input id="field2-foo" type="radio" name="field2" value="foo" checked={{eq value2 "foo"}} required />
+          <label for="field2-foo">foo</label>
+          <input id="field2-na" type="radio" name="field2" value="na" checked={{eq value2 "na"}} required />
+          <label for="gender-na">N/A</label>
+        </fieldset>
+        {{#if (get v.errorMessage "field2")}}
+          <p data-test-error>{{(get v.errorMessage "field2")}}</p>
+        {{/if}}
+      {{/validator-wrapper}}
+    `);
+    await this.pauseTest();
+    assert.ok(1);
+  });
+  test('can validate with external prop change', async function (assert) {
     assert.ok(1);
   });
   test('can handle async validator', async function (assert) {

--- a/tests/integration/components/validator-wrapper-test.js
+++ b/tests/integration/components/validator-wrapper-test.js
@@ -226,41 +226,46 @@ module('Integration | Component | validator-wrapper', (hooks) => {
     );
   });
 
-  skip('can handle multiple input', async function (assert) {
+  test('can handle multiple input', async function (assert) {
     this.model = { email: '', field2: '' };
+    this.customValidator = function customValidator(model) {
+      return { email: 'ok', field2: 'not ok' };
+    };
 
     await render(hbs`
       <ValidatorWrapper
-        @validators={{array this.notLinkedinEmail this.notMsEmail}}
+        @validator={{this.customValidator}}
         @validating={{true}}
         @model={{this.model}}
         as |v|
       >
         <input
           type="email"
-          required
           name="email"
           data-test-input
           value={{this.model.email}}
-          onInput={{fn this.onInput}}
+          onInput={{this.onInput}}
           pattern=".+\.com"
+          required
         />
-        {{#if (get v.errorMessage "simple-email")}}
-          <p data-test-error>{{(get v.errorMessage "simple-email")}}</p>
+        {{#if v.errorMessage.email}}
+          <p data-test-error>{{v.errorMessage.email}}</p>
         {{/if}}
+
         <fieldset name="gender-set" {{on "input" this.onInput2}}>
           <input id="field2-bar" type="radio" name="field2" value="bar" checked={{eq this.model.field2 "bar"}} required />
           <label for="field2-bar">bar</label>
           <input id="field2-foo" type="radio" name="field2" value="foo" checked={{eq this.model.field2 "foo"}} required />
           <label for="field2-foo">foo</label>
           <input id="field2-na" type="radio" name="field2" value="na" checked={{eq this.model.field2 "na"}} required />
-          <label for="gender-na">N/A</label>
+          <label for="field2-na">N/A</label>
         </fieldset>
-        {{#if (get v.errorMessage "field2")}}
-          <p data-test-error>{{(get v.errorMessage "field2")}}</p>
+        {{#if v.errorMessage.field2}}
+          <p data-test-error>{{v.errorMessage.field2}}</p>
         {{/if}}
       </ValidatorWrapper>
     `);
+    await this.pauseTest();
     assert.ok(1);
   });
   test('can validate with external prop change', async function (assert) {
@@ -283,7 +288,7 @@ module('Integration | Component | validator-wrapper', (hooks) => {
         <input
           type={{this.type}}
           value={{this.model.email}}
-          onInput={{fn this.onInput}}
+          onInput={{this.onInput}}
           required
           data-test-input
           name="email"

--- a/tests/unit/utils/array-helpers-test.js
+++ b/tests/unit/utils/array-helpers-test.js
@@ -1,0 +1,10 @@
+import { intersection } from 'ember-form-validation/utils/array-helpers';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | array-helpers', function () {
+  // TODO: Replace this with your real tests.
+  test('it works', function (assert) {
+    assert.deepEqual(intersection([1, 2, 3], [2, 1]), [1, 2]);
+    assert.deepEqual(intersection([], [2, 1]), []);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5105,6 +5105,13 @@ ember-template-recast@^5.0.3:
     tmp "^0.2.1"
     workerpool "^6.1.4"
 
+ember-truth-helpers@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-3.0.0.tgz#86766bdca4ac9b86bce3d262dff2aabc4a0ea384"
+  integrity sha512-hPKG9QqruAELh0li5xaiLZtr88ioWYxWCXisAWHWE0qCP4a2hgtuMzKUPpiTCkltvKjuqpzTZCU4VhQ+IlRmew==
+  dependencies:
+    ember-cli-babel "^7.22.1"
+
 ember-try-config@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ember-try-config/-/ember-try-config-3.0.0.tgz#012d8c90cae9eb624e2b62040bf7e76a1aa58edc"


### PR DESCRIPTION
more than one input elements is foreseeable and normal use case. although it can also significantly increase the complexity for the user--- both `model` and `validator` now it needs to aware of the structure of inner component. however, overall i believe this feature is required and can boost the productivity for form item does has more than one input.

after this change, the wrapper yields on the entire `model` object, the key-value structure represents the value and the associated element name, e.g.
```
{ 'email': 'abc.cde.com' }
```

similarly, the error become an `object` (from `string`) that allows the consumer to manage separately. 