### PR TITLE
Refactor for modifier

### DIFF
--- a/addon/components/validator-container.hbs
+++ b/addon/components/validator-container.hbs
@@ -1,4 +1,4 @@
-<form {{did-insert this.registerElement}} data-test-validator-container novalidate>
+<form {{register-element this.registerElement}} data-test-validator-container novalidate>
   {{yield
     (hash
       validating=this.validating

--- a/addon/components/validator-wrapper.hbs
+++ b/addon/components/validator-wrapper.hbs
@@ -1,3 +1,3 @@
-<div {{install-validation-wrapper this.onInsert this.onReceiveProperties @model}}>
+<div {{install-validation-wrapper @model onInsert=this.onInsert onUpdate=this.onReceiveProperties}}>
   {{yield (hash errorMessage=this.errorMessage)}}
 </div>

--- a/addon/components/validator-wrapper.hbs
+++ b/addon/components/validator-wrapper.hbs
@@ -1,6 +1,3 @@
-<div
-  {{did-update this.onReceiveProperties @model}}
-  {{did-insert this.onInsert @model}}
-  >
+<div {{install-validation-wrapper this.onInsert this.onReceiveProperties @model}}>
   {{yield (hash errorMessage=this.errorMessage)}}
 </div>

--- a/addon/modifiers/install-validation-wrapper.js
+++ b/addon/modifiers/install-validation-wrapper.js
@@ -2,12 +2,13 @@ import Modifier from 'ember-modifier';
 
 export default class InstallValidationWrapper extends Modifier {
   didInstall() {
-    const [onInsert, onUpdate, model] = this.args.positional;
+    const { onInsert } = this.args.named;
+
     onInsert(this.element);
-    onUpdate(this.element, model);
   }
   didUpdateArguments() {
-    const [, onUpdate, model] = this.args.positional;
+    const [model] = this.args.positional;
+    const { onUpdate } = this.args.named;
     onUpdate(this.element, model);
   }
 }

--- a/addon/modifiers/install-validation-wrapper.js
+++ b/addon/modifiers/install-validation-wrapper.js
@@ -1,0 +1,13 @@
+import Modifier from 'ember-modifier';
+
+export default class InstallValidationWrapper extends Modifier {
+  didInstall() {
+    const [onInsert, onUpdate, model] = this.args.positional;
+    onInsert(this.element);
+    onUpdate(this.element, model);
+  }
+  didUpdateArguments() {
+    const [, onUpdate, model] = this.args.positional;
+    onUpdate(this.element, model);
+  }
+}

--- a/addon/modifiers/register-element.js
+++ b/addon/modifiers/register-element.js
@@ -1,0 +1,5 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier(function registerElement(element, [onInsert]) {
+  onInsert(element);
+});

--- a/app/modifiers/install-validation-wrapper.js
+++ b/app/modifiers/install-validation-wrapper.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-form-validation/modifiers/install-validation-wrapper';

--- a/app/modifiers/register-element.js
+++ b/app/modifiers/register-element.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-form-validation/modifiers/register-element';

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
-    "@ember/render-modifiers": "^1.0.2",
     "@ember/test-helpers": "^2.2.5",
     "@embroider/test-setup": "^0.41.0",
     "@glimmer/component": "^1.0.4",
@@ -48,6 +47,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-modifier": "^2.1.2",
     "ember-page-title": "^6.2.2",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.2",

--- a/tests/integration/components/validator-container-test.js
+++ b/tests/integration/components/validator-container-test.js
@@ -4,7 +4,7 @@ import { fillIn, click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
-module('Integration | Component | shared/validator-container', (hooks) => {
+module('Integration | Component | validator-container', (hooks) => {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/tests/integration/components/validator-wrapper-test.js
+++ b/tests/integration/components/validator-wrapper-test.js
@@ -252,7 +252,7 @@ module('Integration | Component | validator-wrapper', (hooks) => {
       <ValidatorWrapper
         @validator={{this.customValidator}}
         @validating={{true}}
-        @model={{this.model}}
+        @model={{hash email=this.model.email field2=this.model.field2}}
         as |v|
       >
         <input

--- a/tests/integration/modifiers/install-validation-wrapper-test.js
+++ b/tests/integration/modifiers/install-validation-wrapper-test.js
@@ -1,0 +1,41 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Modifier | install-validation-wrapper', function (hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function (assert) {
+    this.onInsert = sinon.stub();
+    this.onUpdate = sinon.stub();
+    this.model = {};
+    await render(
+      hbs`<div data-test-element {{install-validation-wrapper this.onInsert this.onUpdate this.model}}></div>`
+    );
+    const element = document.querySelector('[data-test-element]');
+
+    assert.ok(this.onInsert.calledOnce, 'onInsert called after installation');
+    assert.ok(
+      this.onInsert.calledWithExactly(element),
+      'onInsert called with proper params after installation'
+    );
+    assert.ok(this.onUpdate.calledOnce, 'onUpdate called after installation');
+    assert.ok(
+      this.onUpdate.calledWithExactly(element, this.model),
+      'update gets called with the proper parameters after installation'
+    );
+    this.set('model', { foo: 'bar' });
+    assert.ok(this.onInsert.calledOnce, 'onInsert is not invoked on update');
+    assert.ok(
+      this.onUpdate.calledTwice,
+      'onUpdate is called once after change'
+    );
+    assert.ok(
+      this.onUpdate.calledWithExactly(element, this.model),
+      'update gets called with the proper parameters'
+    );
+  });
+});

--- a/tests/integration/modifiers/install-validation-wrapper-test.js
+++ b/tests/integration/modifiers/install-validation-wrapper-test.js
@@ -13,7 +13,7 @@ module('Integration | Modifier | install-validation-wrapper', function (hooks) {
     this.onUpdate = sinon.stub();
     this.model = {};
     await render(
-      hbs`<div data-test-element {{install-validation-wrapper this.onInsert this.onUpdate this.model}}></div>`
+      hbs`<div data-test-element {{install-validation-wrapper this.model onInsert=this.onInsert onUpdate=this.onUpdate}}></div>`
     );
     const element = document.querySelector('[data-test-element]');
 
@@ -22,17 +22,13 @@ module('Integration | Modifier | install-validation-wrapper', function (hooks) {
       this.onInsert.calledWithExactly(element),
       'onInsert called with proper params after installation'
     );
-    assert.ok(this.onUpdate.calledOnce, 'onUpdate called after installation');
-    assert.ok(
-      this.onUpdate.calledWithExactly(element, this.model),
-      'update gets called with the proper parameters after installation'
+    assert.notOk(
+      this.onUpdate.calledOnce,
+      'onUpdate is not called after installation'
     );
     this.set('model', { foo: 'bar' });
     assert.ok(this.onInsert.calledOnce, 'onInsert is not invoked on update');
-    assert.ok(
-      this.onUpdate.calledTwice,
-      'onUpdate is called once after change'
-    );
+    assert.ok(this.onUpdate.calledOnce, 'onUpdate is called once after change');
     assert.ok(
       this.onUpdate.calledWithExactly(element, this.model),
       'update gets called with the proper parameters'

--- a/tests/integration/modifiers/register-element-test.js
+++ b/tests/integration/modifiers/register-element-test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Modifier | registerElement', function (hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function (assert) {
+    this.onInsert = sinon.stub();
+    await render(
+      hbs`<div data-test-element {{register-element this.onInsert}}></div>`
+    );
+
+    assert.ok(
+      this.onInsert.calledWithExactly(
+        document.querySelector('[data-test-element]')
+      )
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,7 +76,7 @@
     browserslist "^4.16.6"
     semver "^6.3.0"
 
-"@babel/helper-create-class-features-plugin@^7.14.5", "@babel/helper-create-class-features-plugin@^7.14.6", "@babel/helper-create-class-features-plugin@^7.5.5":
+"@babel/helper-create-class-features-plugin@^7.14.5", "@babel/helper-create-class-features-plugin@^7.14.6", "@babel/helper-create-class-features-plugin@^7.5.5", "@babel/helper-create-class-features-plugin@^7.8.3":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.6.tgz#f114469b6c06f8b5c59c6c4e74621f5085362542"
   integrity sha512-Z6gsfGofTxH/+LQXqYEK45kxmcensbzmk/oi8DmaQytlQCgqNZt9XQF8iqlI/SeXWVjaMNxvYvzaYw+kh42mDg==
@@ -339,7 +339,7 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
 
-"@babel/plugin-proposal-nullish-coalescing-operator@^7.14.5":
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.14.5", "@babel/plugin-proposal-nullish-coalescing-operator@^7.4.4":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.14.5.tgz#ee38589ce00e2cc59b299ec3ea406fcd3a0fdaf6"
   integrity sha512-gun/SOnMqjSb98Nkaq2rTKMwervfdAoz6NphdY0vTfuzMfryj+tDGb2n6UkDKwez+Y8PZDhE3D143v6Gepp4Hg==
@@ -374,7 +374,7 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
 
-"@babel/plugin-proposal-optional-chaining@^7.14.5":
+"@babel/plugin-proposal-optional-chaining@^7.14.5", "@babel/plugin-proposal-optional-chaining@^7.6.0":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.14.5.tgz#fa83651e60a360e3f13797eef00b8d519695b603"
   integrity sha512-ycz+VOzo2UbWNI1rQXxIuMOzrDdHGrI23fRiz/Si2R4kv2XZQ1BK8ccdHwehMKBlcH/joGW/tzrUmo67gbJHlQ==
@@ -514,7 +514,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-typescript@^7.14.5", "@babel/plugin-syntax-typescript@^7.2.0":
+"@babel/plugin-syntax-typescript@^7.14.5", "@babel/plugin-syntax-typescript@^7.2.0", "@babel/plugin-syntax-typescript@^7.8.3":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz#b82c6ce471b165b5ce420cf92914d6fb46225716"
   integrity sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==
@@ -799,6 +799,15 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-typescript" "^7.2.0"
 
+"@babel/plugin-transform-typescript@~7.8.0":
+  version "7.8.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.8.7.tgz#48bccff331108a7b3a28c3a4adc89e036dc3efda"
+  integrity sha512-7O0UsPQVNKqpHeHLpfvOG4uXmlw+MOxYvUv6Otc9uH5SYMIxvF6eBdjkWvC3f9G+VXe0RsNExyAQBeTRug/wqQ==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-typescript" "^7.8.3"
+
 "@babel/plugin-transform-unicode-escapes@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.14.5.tgz#9d4bd2a681e3c5d7acf4f57fa9e51175d91d0c6b"
@@ -997,14 +1006,6 @@
     inquirer "^7.3.3"
     mkdirp "^1.0.4"
     silent-error "^1.1.1"
-
-"@ember/render-modifiers@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@ember/render-modifiers/-/render-modifiers-1.0.2.tgz#2e87c48db49d922ce4850d707215caaac60d8444"
-  integrity sha512-6tEnHl5+62NTSAG2mwhGMFPhUrJQjoVqV+slsn+rlTknm2Zik+iwxBQEbwaiQOU1FUYxkS8RWcieovRNMR8inQ==
-  dependencies:
-    ember-cli-babel "^7.10.0"
-    ember-modifier-manager-polyfill "^1.1.0"
 
 "@ember/test-helpers@^2.2.5":
   version "2.2.8"
@@ -4762,6 +4763,26 @@ ember-cli-typescript@^2.0.2:
     stagehand "^1.0.0"
     walk-sync "^1.0.0"
 
+ember-cli-typescript@^3.1.3:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz#21d6ccd670d1f2e34c9cce68c6e32c442f46806b"
+  integrity sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==
+  dependencies:
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.4.4"
+    "@babel/plugin-proposal-optional-chaining" "^7.6.0"
+    "@babel/plugin-transform-typescript" "~7.8.0"
+    ansi-to-html "^0.6.6"
+    broccoli-stew "^3.0.0"
+    debug "^4.0.0"
+    ember-cli-babel-plugin-helpers "^1.0.0"
+    execa "^3.0.0"
+    fs-extra "^8.0.0"
+    resolve "^1.5.0"
+    rsvp "^4.8.1"
+    semver "^6.3.0"
+    stagehand "^1.0.0"
+    walk-sync "^2.0.0"
+
 ember-cli-typescript@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz#54d08fc90318cc986f3ea562f93ce58a6cc4c24d"
@@ -4909,7 +4930,7 @@ ember-cli@~3.27.0:
     workerpool "^6.0.3"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1:
+ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1, ember-compatibility-helpers@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.4.tgz#70e0fef7048969141626eed6006f3880df612cd1"
   integrity sha512-qjzQVtogyYJrSs6I4DuyCDwDCaj5JWBVNPoZDZBk8pt7caNoN0eBYRYJdin95QKaNMQODxTLPWaI4UUDQ1YWhg==
@@ -4919,7 +4940,7 @@ ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-co
     fs-extra "^9.1.0"
     semver "^5.4.1"
 
-ember-destroyable-polyfill@^2.0.3:
+ember-destroyable-polyfill@^2.0.2, ember-destroyable-polyfill@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.3.tgz#1673ed66609a82268ef270a7d917ebd3647f11e1"
   integrity sha512-TovtNqCumzyAiW0/OisSkkVK93xnVF4NRU6+FN0ubpfwEOpRrmM2RqDwXI6YAChCgSHON1cz0DfQStpA1Gjuuw==
@@ -4956,7 +4977,7 @@ ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
-ember-modifier-manager-polyfill@^1.1.0:
+ember-modifier-manager-polyfill@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz#cf4444e11a42ac84f5c8badd85e635df57565dda"
   integrity sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==
@@ -4964,6 +4985,19 @@ ember-modifier-manager-polyfill@^1.1.0:
     ember-cli-babel "^7.10.0"
     ember-cli-version-checker "^2.1.2"
     ember-compatibility-helpers "^1.2.0"
+
+ember-modifier@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-2.1.2.tgz#62d18faedf972dcd9d34f90d5321fbc943d139b1"
+  integrity sha512-3Lsu1fV1sIGa66HOW07RZc6EHISwKt5VA5AUnFss2HX6OTfpxTJ2qvPctt2Yt0XPQXJ4G6BQasr/F35CX7UGJA==
+  dependencies:
+    ember-cli-babel "^7.22.1"
+    ember-cli-normalize-entity-name "^1.0.0"
+    ember-cli-string-utils "^1.1.0"
+    ember-cli-typescript "^3.1.3"
+    ember-compatibility-helpers "^1.2.4"
+    ember-destroyable-polyfill "^2.0.2"
+    ember-modifier-manager-polyfill "^1.2.0"
 
 ember-page-title@^6.2.2:
   version "6.2.2"
@@ -5562,6 +5596,22 @@ execa@^2.0.0:
     is-stream "^2.0.0"
     merge-stream "^2.0.0"
     npm-run-path "^3.0.0"
+    onetime "^5.1.0"
+    p-finally "^2.0.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
+execa@^3.0.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-3.4.0.tgz#c08ed4550ef65d858fac269ffc8572446f37eb89"
+  integrity sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    human-signals "^1.1.1"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.0"
     onetime "^5.1.0"
     p-finally "^2.0.0"
     signal-exit "^3.0.2"


### PR DESCRIPTION
the current logic was relying on `ember/render-modifier`, which was an early version of modifier and meant to polyfill the function gap for developer just switch to glimmer from ember component. and the `render-modifier` has been marked as `deprecated` from the recent version of Ember. the recommendation is to migrate to ember-modifier.

![error](https://user-images.githubusercontent.com/3668313/126431878-0301c306-7a17-462e-b45d-476524a9f81d.PNG)
